### PR TITLE
more precise covariance for point cloud

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 include("${PCL_SOURCE_DIR}/cmake/pcl_utils.cmake")
-set(PCL_VERSION 1.9.0 CACHE STRING "PCL version")
+set(PCL_VERSION 1.9.1 CACHE STRING "PCL version")
 DISSECT_VERSION()
 GET_OS_INFO()
 SET_INSTALL_DIRS()

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -589,16 +589,14 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   centroid[0] = accu[6]; centroid[1] = accu[7]; centroid[2] = accu[8];
   centroid[3] = 1;
 
-
   if (cloud.is_dense)
   {
-    point_count = indices.size ();
     for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
     {
       //const PointT& point = cloud[*iIt];
-      double xm = cloud[*iIt].x - accu[6];
-      double ym = cloud[*iIt].y - accu[7];
-      double zm = cloud[*iIt].z - accu[8];
+      const double xm = cloud[*iIt].x - accu[6];
+      const double ym = cloud[*iIt].y - accu[7];
+      const double zm = cloud[*iIt].z - accu[8];
       accu [0] += xm * xm;
       accu [1] += xm * ym;
       accu [2] += xm * zm;
@@ -609,16 +607,14 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   }
   else
   {
-    point_count = 0;
     for (std::vector<int>::const_iterator iIt = indices.begin (); iIt != indices.end (); ++iIt)
     {
       if (!isFinite (cloud[*iIt]))
         continue;
 
-      ++point_count;
-      double xm = cloud[*iIt].x - accu[6];
-      double ym = cloud[*iIt].y - accu[7];
-      double zm = cloud[*iIt].z - accu[8];
+      const double xm = cloud[*iIt].x - accu[6];
+      const double ym = cloud[*iIt].y - accu[7];
+      const double zm = cloud[*iIt].z - accu[8];
       accu [0] += xm * xm;
       accu [1] += xm * ym;
       accu [2] += xm * zm;
@@ -628,7 +624,7 @@ pcl::computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
     }
   }
 
-  accu /= static_cast<Scalar> (point_count);
+  accu /= static_cast<Scalar> (point_count);  // ignore (divide again) 6, 7, 8 entries
   covariance_matrix.coeffRef (0) = accu [0];
   covariance_matrix.coeffRef (1) = accu [1];
   covariance_matrix.coeffRef (2) = accu [2];


### PR DESCRIPTION
point cloud usually have large z coordinates compared to xy. it is not a good idea to sum squared coordinates before subtracting the bias (mean). 

this was leading to imprecision in covariance computation, which affected eigen values and curvature measurement for multi-plane segmentation.

here, i compute mean first, then subtract points from mean before squaring. this doubles the for loops. there might be a more efficient way to do this