### PR TITLE
speed up clusteredTemplates access

### DIFF
--- a/recognition/src/linemod.cpp
+++ b/recognition/src/linemod.cpp
@@ -205,7 +205,7 @@ pcl::LINEMOD::removeOverlappingDetections (
     templateClusters[key].push_back(template_index);
   }
 
-  std::map<size_t, size_t> clusteredTemplates;
+  std::vector<size_t> clusteredTemplates(n_templates, std::numeric_limits<size_t>::max()); // index is template_index
   if (templateClusters.size() <= 1) {
     PCL_ERROR ("[removeOverlappingDetections] All %u templates got grouped into %u cluster(s). Either rotation threshold=%.4f is too large, or template rotations are not set properly.\n"
                "Making each template in its own cluster for now...\n", n_templates, templateClusters.size(), rotation_clustering_threshold);


### PR DESCRIPTION
Issue this MR is trying to solve
=========================

In master following chunk of code was taking 300 ms on my test case, accessing ``clusteredTemplates`` of type std map taking log(N) time each.
```
    for (size_t template_index = 0; template_index < n_templates; ++template_index)
    {
      // Skip templates that does not belong to the same cluster
      // This is also important to protect wrong ID assignment in case all rotations are not set, thus ended up to have the same distance
      if (clusteredTemplates[best_template_id] != clusteredTemplates[template_index]) {
        continue;
      }
    ...
```

In this MR
==========

I use ``std::vector`` for ``clusteredTemplates``. Previously, it was a map whose keys were consecutive number from 0 to N-1 where N is size of ``clusteredTemplates``.  Equivalent can be achieved by a vector whose index can server the same purpose as key of std map of characteristic that keys are consecutive integer numbers from 0. Vector element access is constant time, and this function finishes in a few ms. 