### PR TITLE
Bullseye

### DIFF
--- a/common/include/pcl/PCLPointCloud2.h
+++ b/common/include/pcl/PCLPointCloud2.h
@@ -3,12 +3,12 @@
 
 #ifdef USE_ROS
    #error USE_ROS setup requires PCL to compile against ROS message headers, which is now deprecated
-#endif 
+#endif
 
 #include <string>
 #include <vector>
 #include <ostream>
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 
 // Include the correct Header path here
 #include <pcl/PCLHeader.h>
@@ -23,9 +23,9 @@ namespace pcl
                      is_bigendian (false), point_step (0), row_step (0),
                      data (), is_dense (false)
     {
-#if defined(BOOST_BIG_ENDIAN)
+#if BOOST_ENDIAN_BIG_BYTE
       is_bigendian = true;
-#elif defined(BOOST_LITTLE_ENDIAN)
+#elif BOOST_ENDIAN_LITTLE_BYTE
       is_bigendian = false;
 #else
 #error "unable to determine system endianness"

--- a/io/include/pcl/io/ply/byte_order.h
+++ b/io/include/pcl/io/ply/byte_order.h
@@ -32,7 +32,7 @@
  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
- *  
+ *
  * $Id$
  *
  */
@@ -40,7 +40,7 @@
 #ifndef PCL_IO_PLY_BYTE_ORDER_H
 #define PCL_IO_PLY_BYTE_ORDER_H
 
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 
 namespace pcl
 {
@@ -58,16 +58,16 @@ namespace pcl
       {
         little_endian_byte_order,
         big_endian_byte_order,
-#if defined(BOOST_BIG_ENDIAN)
+#if BOOST_ENDIAN_BIG_BYTE
         host_byte_order = big_endian_byte_order,
-#elif defined(BOOST_LITTLE_ENDIAN)
+#elif BOOST_ENDIAN_LITTLE_BYTE
         host_byte_order = little_endian_byte_order,
 #else
 #error "unable to determine system endianness"
 #endif
         network_byte_order = big_endian_byte_order
       };
-      
+
       template <std::size_t N>
       void swap_byte_order (char* bytes);
 

--- a/kdtree/CMakeLists.txt
+++ b/kdtree/CMakeLists.txt
@@ -28,7 +28,7 @@ if(build)
     set(LIB_NAME "pcl_${SUBSYS_NAME}")
     include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
     PCL_ADD_LIBRARY("${LIB_NAME}" "${SUBSYS_NAME}" ${srcs} ${incs} ${impl_incs})
-    target_link_libraries("${LIB_NAME}" pcl_common ${FLANN_LIBRARIES})
+    target_link_libraries("${LIB_NAME}" pcl_common ${FLANN_LIBRARIES} lz4)
     set(EXT_DEPS flann)
     PCL_MAKE_PKGCONFIG("${LIB_NAME}" "${SUBSYS_NAME}" "${SUBSYS_DESC}"
                        "${SUBSYS_DEPS}" "${EXT_DEPS}" "" "" "")

--- a/kdtree/CMakeLists.txt
+++ b/kdtree/CMakeLists.txt
@@ -28,7 +28,7 @@ if(build)
     set(LIB_NAME "pcl_${SUBSYS_NAME}")
     include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
     PCL_ADD_LIBRARY("${LIB_NAME}" "${SUBSYS_NAME}" ${srcs} ${incs} ${impl_incs})
-    target_link_libraries("${LIB_NAME}" pcl_common ${FLANN_LIBRARIES} lz4)
+    target_link_libraries("${LIB_NAME}" pcl_common ${FLANN_LIBRARIES})
     set(EXT_DEPS flann)
     PCL_MAKE_PKGCONFIG("${LIB_NAME}" "${SUBSYS_NAME}" "${SUBSYS_DESC}"
                        "${SUBSYS_DEPS}" "${EXT_DEPS}" "" "" "")

--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -541,7 +541,7 @@ namespace pcl
           if ( indices[i].empty () )
             continue;
 
-          if ( children_[i] == false )
+          if ( children_[i] == NULL )
           {
             createChild (i);
           }
@@ -796,7 +796,7 @@ namespace pcl
         if(indices[i].empty ())
           continue;
 
-        if( children_[i] == false )
+        if( children_[i] == NULL )
         {
           assert (i < 8);
           createChild (i);

--- a/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
@@ -74,7 +74,7 @@ namespace pcl
     OutofcoreOctreeDiskContainer<PointT>::rand_gen_ (static_cast<unsigned int> (std::time(NULL)));
 
     template<typename PointT>
-    boost::uuids::random_generator OutofcoreOctreeDiskContainer<PointT>::uuid_gen_ (&rand_gen_);
+    boost::uuids::basic_random_generator<boost::mt19937> OutofcoreOctreeDiskContainer<PointT>::uuid_gen_ (&rand_gen_);
 
     template<typename PointT>
     const uint64_t OutofcoreOctreeDiskContainer<PointT>::READ_BLOCK_SIZE_ = static_cast<uint64_t> (2e12);

--- a/outofcore/include/pcl/outofcore/octree_disk_container.h
+++ b/outofcore/include/pcl/outofcore/octree_disk_container.h
@@ -296,7 +296,7 @@ namespace pcl
 
         static boost::mutex rng_mutex_;
         static boost::mt19937 rand_gen_;
-        static boost::uuids::random_generator uuid_gen_;
+        static boost::uuids::basic_random_generator<boost::mt19937> uuid_gen_;
 
     };
   } //namespace outofcore

--- a/recognition/include/pcl/recognition/color_gradient_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_modality.h
@@ -162,11 +162,11 @@ namespace pcl
       }
 
       /** \brief Returns a point cloud containing the max-RGB gradients. */
-      inline pcl::PointCloud<pcl::GradientXY> &
-      getMaxColorGradients ()
-      {
-        return (color_gradients_);
-      }
+      //inline pcl::PointCloud<pcl::GradientXY> &
+      //getMaxColorGradients ()
+      //{
+      //  return (color_gradients_);
+      //}
   
       /** \brief Extracts features from this modality within the specified mask.
         * \param[in] mask defines the areas where features are searched in. 

--- a/recognition/include/pcl/recognition/grayscale_gradient_modality.h
+++ b/recognition/include/pcl/recognition/grayscale_gradient_modality.h
@@ -162,11 +162,11 @@ namespace pcl
       }
 
       /** \brief Returns a point cloud containing the max-RGB gradients. */
-      inline pcl::PointCloud<pcl::GradientXY> &
-      getMaxGradients ()
-      {
-        return (gradients_);
-      }
+      //inline pcl::PointCloud<pcl::GradientXY> &
+      //getMaxGradients ()
+      //{
+      //  return (gradients_);
+      //}
   
       /** \brief Extracts features from this modality within the specified mask.
         * \param[in] mask defines the areas where features are searched in. 

--- a/segmentation/include/pcl/segmentation/ground_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/ground_plane_comparator.h
@@ -147,7 +147,7 @@ namespace pcl
       const std::vector<float>&
       getPlaneCoeffD () const
       {
-        return (plane_coeff_d_);
+        return (*plane_coeff_d_);
       }
 
       /** \brief Set the tolerance in radians for difference in normal direction between neighboring points, to be considered part of the same plane.

--- a/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
+++ b/segmentation/include/pcl/segmentation/plane_coefficient_comparator.h
@@ -141,7 +141,7 @@ namespace pcl
       const std::vector<float>&
       getPlaneCoeffD () const
       {
-        return (plane_coeff_d_);
+        return (*plane_coeff_d_);
       }
 
       /** \brief Set the tolerance in radians for difference in normal direction between neighboring points, to be considered part of the same plane.

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -95,7 +95,11 @@
 #include <pcl/visualization/common/shapes.h>
 #include <pcl/visualization/pcl_visualizer.h>
 #include <pcl/common/time.h>
+#if BOOST_VERSION>=106600
+#include <boost/uuid/detail/sha1.hpp>
+#else
 #include <boost/uuid/sha1.hpp>
+#endif
 #include <boost/filesystem.hpp>
 #include <pcl/console/parse.h>
 


### PR DESCRIPTION
- cherry-picked https://github.com/PointCloudLibrary/pcl/commit/a0b3ce9ca5c69a945695c1c83dab7937a3d99b83 and https://github.com/PointCloudLibrary/pcl/pull/2801/commits/dbadf4143bdc503203da0d87a786752a60d29e76

- https://github.com/mujin/pcl/commit/d0d39e62e89bd64455326f26501ba065ff930972 did some bad things for GCC8, but I don't come up with proper fix so I removed getMaxColorGradients function. It is not used in our code base.

the build looks quite stable so far.