### PR TITLE
[Linemod] fix normal quantization issue: shift each bin value by one in `quantizeSurfaceNormals`

### DIFF
--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -1400,7 +1400,7 @@ pcl::SurfaceNormalModality<PointInT>::quantizeSurfaceNormals ()
       const float normal_y = surface_normals_ (col_index, row_index).normal_y;
       const float normal_z = surface_normals_ (col_index, row_index).normal_z;
 
-      if (pcl_isnan(normal_x) || pcl_isnan(normal_y) || pcl_isnan(normal_z) || normal_z > 0)
+      if (pcl_isnan(normal_x) || pcl_isnan(normal_y) || pcl_isnan(normal_z) || normal_z > 0 || (normal_x == 0 && normal_y == 0))
       {
         quantized_surface_normals_ (col_index, row_index) = 0;
         continue;
@@ -1414,7 +1414,7 @@ pcl::SurfaceNormalModality<PointInT>::quantizeSurfaceNormals ()
       if (angle < 0.0f) angle += 360.0f;
       if (angle >= 360.0f) angle -= 360.0f;
 
-      int bin_index = static_cast<int> (angle*8.0f/360.0f);
+      int bin_index = static_cast<int> (angle*8.0f/360.0f+1);
 
       //quantized_surface_normals_.data[row_index*width+col_index] = 0x1 << bin_index;
       quantized_surface_normals_ (col_index, row_index) = static_cast<unsigned char> (bin_index);


### PR DESCRIPTION
### Issue:
- Currently in `quantizeSurfaceNormals` used in `Linemod2D`, 2D normal angles between -11 to 33 degree will be quantized to 0, while invalid normals (e.g. normals that are (0,0,0)) will also be quantized to 0. Thus it will cause angles between -11 to 33 degree being ignored same as invalid normals and cause holes in `sceneModalityMap` where normals actually exist.

### Fix:
- Put normals that are (0,0,0) as invalid as well and directly set their quantized value to 0.
- Shift all the `bin_index` by plus one, so that angles between -11 to 33 degree are quantized to 1.