### PR TITLE
[Linemod] fix normal quantization issue2: in `quantizeSurfaceNormals`, restrict bin_index to 8 when it overflows to 9

### DIFF
--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -1415,6 +1415,10 @@ pcl::SurfaceNormalModality<PointInT>::quantizeSurfaceNormals ()
       if (angle >= 360.0f) angle -= 360.0f;
 
       int bin_index = static_cast<int> (angle*8.0f/360.0f+1);
+      // when angle is 359.999f, bin_index can overflow to 9
+      if (bin_index >= 9){
+        bin_index -= 1;
+      }
 
       //quantized_surface_normals_.data[row_index*width+col_index] = 0x1 << bin_index;
       quantized_surface_normals_ (col_index, row_index) = static_cast<unsigned char> (bin_index);

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -1417,7 +1417,7 @@ pcl::SurfaceNormalModality<PointInT>::quantizeSurfaceNormals ()
       int bin_index = static_cast<int> (angle*8.0f/360.0f+1);
       // when angle is 359.999f, bin_index can overflow to 9
       if (bin_index >= 9){
-        bin_index -= 1;
+        bin_index = 8;
       }
 
       //quantized_surface_normals_.data[row_index*width+col_index] = 0x1 << bin_index;


### PR DESCRIPTION
Issue:
bin_index in `quantizeSurfaceNormals` may overflow to 9 because of numerical error and cause segmentation fault.

Solve:
restrict bin_index to maximum 8.