### PR TITLE
Improve linemod2d clustering

### DIFF
--- a/recognition/include/pcl/recognition/linemod.h
+++ b/recognition/include/pcl/recognition/linemod.h
@@ -369,12 +369,19 @@ namespace pcl
                                          std::vector<std::vector<LINEMODDetection>>& grouped_detections,
                                          const size_t grouping_threshold) const;
 
+      /** \brief Remove duplicated candidates (with same templateID) in a local neighborhood, in non-maximum-suppression style.
+        * \param[in, out] detections list of candidate detections.
+        * \param[in] translation_clustering_threshold threshold in terms of translation to select neighborhood.
+        * \param[in] rotation_clustering_threshold (not used!) threshold in terms of rotation (meaning 3d rotation, namely different template) to select neighborbood.
+        * \param[in] use_critical_direction_in_2D_clustering enable finer clustering in critical direction. For super long object, the direction perpendicular to longest axis is critical.
+        * \param[in] translation_clustering_threshold_2D_in_critical_direction a (usually much smaller than translation_clustering_threshold) threshold of translation in critical direction. 
+        */
       void
       removeOverlappingDetections (std::vector<LINEMODDetection> & detections,
                                    size_t translation_clustering_threshold,
                                    float rotation_clustering_threshold,
-                                   bool useCriticalDirectionIn2DClustering = false,
-                                   size_t translationClusteringThreshold2DInCriticalDirection = 0) const;
+                                   bool use_critical_direction_in_2D_clustering = false,
+                                   size_t translation_clustering_threshold_2D_in_critical_direction = 1) const;
 
       void
       sortDetections (std::vector<LINEMODDetection> & detections) const;

--- a/recognition/include/pcl/recognition/linemod.h
+++ b/recognition/include/pcl/recognition/linemod.h
@@ -373,15 +373,13 @@ namespace pcl
         * \param[in, out] detections list of candidate detections.
         * \param[in] translation_clustering_threshold threshold in terms of translation to select neighborhood.
         * \param[in] rotation_clustering_threshold (not used!) threshold in terms of rotation (meaning 3d rotation, namely different template) to select neighborbood.
-        * \param[in] use_critical_direction_in_2D_clustering enable finer clustering in critical direction. For super long object, the direction perpendicular to longest axis is critical.
-        * \param[in] translation_clustering_threshold_2D_in_critical_direction a (usually much smaller than translation_clustering_threshold) threshold of translation in critical direction. 
+        * \param[in] translation_clustering_threshold_2D_in_narrow_direction_of_long_and_narrow_template a (usually much smaller than translation_clustering_threshold) threshold of translation in narrow direction of template. 
         */
       void
       removeOverlappingDetections (std::vector<LINEMODDetection> & detections,
                                    size_t translation_clustering_threshold,
                                    float rotation_clustering_threshold,
-                                   bool use_critical_direction_in_2D_clustering = false,
-                                   size_t translation_clustering_threshold_2D_in_critical_direction = 1) const;
+                                   size_t translation_clustering_threshold_2D_in_narrow_direction_of_long_and_narrow_template = 1) const;
 
       void
       sortDetections (std::vector<LINEMODDetection> & detections) const;

--- a/recognition/include/pcl/recognition/linemod.h
+++ b/recognition/include/pcl/recognition/linemod.h
@@ -372,7 +372,9 @@ namespace pcl
       void
       removeOverlappingDetections (std::vector<LINEMODDetection> & detections,
                                    size_t translation_clustering_threshold,
-                                   float rotation_clustering_threshold) const;
+                                   float rotation_clustering_threshold,
+                                   bool useCriticalDirectionIn2DClustering = false,
+                                   size_t translationClusteringThreshold2DInCriticalDirection = 0) const;
 
       void
       sortDetections (std::vector<LINEMODDetection> & detections) const;

--- a/recognition/include/pcl/recognition/sparse_quantized_multi_mod_template.h
+++ b/recognition/include/pcl/recognition/sparse_quantized_multi_mod_template.h
@@ -117,6 +117,9 @@ namespace pcl
     /** \brief The rotations assigned to the template. */
     float rx, ry, rz;
 
+    /** \brief for super long object, the direction perpendiculr to longest axis is critical (should lower clustering threshold)*/
+    float criticalDirection[2] = {0.0, 0.0};
+
     /** \brief The region assigned to the template. */
     RegionXY region;
 

--- a/recognition/include/pcl/recognition/sparse_quantized_multi_mod_template.h
+++ b/recognition/include/pcl/recognition/sparse_quantized_multi_mod_template.h
@@ -109,7 +109,7 @@ namespace pcl
   struct SparseQuantizedMultiModTemplate
   {
     /** \brief Constructor. */
-    SparseQuantizedMultiModTemplate () : features (), rx (0.f), ry (0.f), rz (0.f), region () {}
+    SparseQuantizedMultiModTemplate () : features (), rx (0.f), ry (0.f), rz (0.f), criticalDirection{0.f, 0.f}, region () {}
 
     /** \brief The storage for the multi-modality features. */
     std::vector<QuantizedMultiModFeature> features;
@@ -117,8 +117,8 @@ namespace pcl
     /** \brief The rotations assigned to the template. */
     float rx, ry, rz;
 
-    /** \brief for super long object, the direction perpendiculr to longest axis is critical (should lower clustering threshold)*/
-    float criticalDirection[2] = {0.0, 0.0};
+    /** \brief for super long object, the direction perpendicular to longest axis is critical (should lower clustering threshold)*/
+    float criticalDirection[2];
 
     /** \brief The region assigned to the template. */
     RegionXY region;

--- a/recognition/include/pcl/recognition/sparse_quantized_multi_mod_template.h
+++ b/recognition/include/pcl/recognition/sparse_quantized_multi_mod_template.h
@@ -109,7 +109,7 @@ namespace pcl
   struct SparseQuantizedMultiModTemplate
   {
     /** \brief Constructor. */
-    SparseQuantizedMultiModTemplate () : features (), rx (0.f), ry (0.f), rz (0.f), criticalDirection{0.f, 0.f}, region () {}
+    SparseQuantizedMultiModTemplate () : features (), rx (0.f), ry (0.f), rz (0.f), narrowDirectionOfLongAndNarrowTemplate{0.f, 0.f}, region () {}
 
     /** \brief The storage for the multi-modality features. */
     std::vector<QuantizedMultiModFeature> features;
@@ -117,8 +117,8 @@ namespace pcl
     /** \brief The rotations assigned to the template. */
     float rx, ry, rz;
 
-    /** \brief for super long object, the direction perpendicular to longest axis is critical (should lower clustering threshold)*/
-    float criticalDirection[2];
+    /** \brief for super long and narrow template*/
+    float narrowDirectionOfLongAndNarrowTemplate[2];
 
     /** \brief The region assigned to the template. */
     RegionXY region;

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -1416,10 +1416,11 @@ pcl::SurfaceNormalModality<PointInT>::quantizeSurfaceNormals ()
 
       int bin_index = static_cast<int> (angle*8.0f/360.0f+1);
       // when angle is 359.999f, bin_index can overflow to 9
+      
       if (bin_index >= 9){
         bin_index = 8;
       }
-
+      
       //quantized_surface_normals_.data[row_index*width+col_index] = 0x1 << bin_index;
       quantized_surface_normals_ (col_index, row_index) = static_cast<unsigned char> (bin_index);
     }

--- a/recognition/src/linemod.cpp
+++ b/recognition/src/linemod.cpp
@@ -182,19 +182,20 @@ pcl::LINEMOD::removeOverlappingDetections (
 {
   // check if clustering is disabled
   if (translation_clustering_threshold == 0 && rotation_clustering_threshold == 0.f) {
+    PCL_ERROR ("clustering is disabled, as translation_clustering_threshold = %d and rotation_clustering_threshold = %g\n", translation_clustering_threshold, rotation_clustering_threshold);
     return;
   }
   if (translation_clustering_threshold == 0) {
     translation_clustering_threshold = 1;
   }
-  if (rotation_clustering_threshold == 0.f) {
-    rotation_clustering_threshold = std::numeric_limits<float>::epsilon();
-  }
+  // if (rotation_clustering_threshold == 0.f) {
+  //   rotation_clustering_threshold = std::numeric_limits<float>::epsilon();
+  // }
 
   const size_t n_templates = templates_.size ();
   
-  PCL_INFO ("[removeOverlappingDetections] All %u templates got grouped into %u cluster(s). Either rotation threshold=%.4f is too large, or template rotations are not set properly.\n"
-            "Making each template in its own cluster\n", n_templates, 1, rotation_clustering_threshold);
+  // PCL_INFO ("[removeOverlappingDetections] All %u templates got grouped into %u cluster(s). Either rotation threshold=%.4f is too large, or template rotations are not set properly.\n"
+  //           "Making each template in its own cluster\n", n_templates, 1, rotation_clustering_threshold);
 
   // compute overlap between each detection
   const size_t nr_detections = detections.size ();

--- a/recognition/src/linemod.cpp
+++ b/recognition/src/linemod.cpp
@@ -254,10 +254,10 @@ pcl::LINEMOD::removeOverlappingDetections (
       criticalDirection[1] = templates_[clusteredTemplates[d.template_id]].criticalDirection[1];
       float criticalDistance = static_cast< float >( d.x * criticalDirection[0] + d.y * criticalDirection[1] ); //std::sqrt(static_cast< float >( d.x * d.x + d.y * d.y ));
       criticalDistanceInt = static_cast< int >(criticalDistance / translationClusteringThreshold2DInCriticalDirection);
-      PCL_INFO ("[linemod2D_CriticalDirectionBasedClustering]: template %d, criticalDistanceInt %d, translation_clustering_threshold %d\n", d.template_id, criticalDistanceInt, translation_clustering_threshold);
+      // PCL_INFO ("[linemod2D_CriticalDirectionBasedClustering]: template %d, criticalDistanceInt %d, translation_clustering_threshold %d\n", d.template_id, criticalDistanceInt, translation_clustering_threshold);
     }
     else{
-      criticalDistanceInt = 0;
+      criticalDistanceInt = 0;  //not using critical-direction
     }
     
     const ClusteringKey key = {
@@ -292,7 +292,6 @@ pcl::LINEMOD::removeOverlappingDetections (
     float average_region_y = 0.0f;
 
     const size_t elements_in_cluster = cluster.size ();
-    float sum_score = 0.0f;
     for (size_t cluster_index = 0; cluster_index < elements_in_cluster; ++cluster_index)
     {
       const size_t detection_id = cluster[cluster_index];
@@ -300,7 +299,6 @@ pcl::LINEMOD::removeOverlappingDetections (
       const pcl::SparseQuantizedMultiModTemplate& template_ = templates_[d.template_id];
 
       const float weight = d.score * d.score;
-      sum_score += d.score;
 
       weight_sum += weight;
 
@@ -312,7 +310,6 @@ pcl::LINEMOD::removeOverlappingDetections (
       average_region_x += static_cast<float>(d.x) * weight;
       average_region_y += static_cast<float>(d.y) * weight;
     }
-    // PCL_INFO ("[bao]: cluster_index %d, numInCluster %d, averageScore %g, bestScore %g\n", cluster_id, elements_in_cluster, sum_score/elements_in_cluster, detections[cluster[itIndexToBestScoreInCluster->second]].score);
 
     const float inv_weight_sum = 1.0f / weight_sum;
 
@@ -341,13 +338,6 @@ pcl::LINEMOD::removeOverlappingDetections (
 
     LINEMODDetection detection;
     detection = detections[cluster[itIndexToBestScoreInCluster->second]];
-    // TODO:add also distant one in shortest extents' direction (assume always the same template in one cluster) 
-
-    // detection.template_id = best_template_id;
-    // detection.score = average_score * inv_weight_sum * std::exp(-0.5f / elements_in_cluster);
-    // detection.scale = average_scale * inv_weight_sum;
-    // detection.x = int (average_region_x * inv_weight_sum);
-    // detection.y = int (average_region_y * inv_weight_sum);
 
     clustered_detections.push_back (detection);
   }

--- a/recognition/src/linemod.cpp
+++ b/recognition/src/linemod.cpp
@@ -177,8 +177,7 @@ pcl::LINEMOD::removeOverlappingDetections (
     std::vector<LINEMODDetection> & detections,
     size_t translation_clustering_threshold,
     float rotation_clustering_threshold,
-    bool use_critical_direction_in_2D_clustering,
-    size_t translation_clustering_threshold_2D_in_critical_direction) const
+    size_t translation_clustering_threshold_2D_in_narrow_direction_of_long_and_narrow_template) const
 {
   // check if clustering is disabled
   if (translation_clustering_threshold == 0 && rotation_clustering_threshold == 0.f) {
@@ -207,25 +206,20 @@ pcl::LINEMOD::removeOverlappingDetections (
   {
     const LINEMODDetection& d = detections[detection_id];
     
-    // use critical Direction Based Clustering for super long object
-    int critical_distance_int;
-    if(use_critical_direction_in_2D_clustering){
-      float criticalDirection[2] = {0.0, 0.0};
-      criticalDirection[0] = templates_[d.template_id].criticalDirection[0];
-      criticalDirection[1] = templates_[d.template_id].criticalDirection[1];
-      float criticalDistance = static_cast< float >( d.x * criticalDirection[0] + d.y * criticalDirection[1] ); //std::sqrt(static_cast< float >( d.x * d.x + d.y * d.y ));
-      critical_distance_int = static_cast< int >(criticalDistance / translation_clustering_threshold_2D_in_critical_direction);
-      // PCL_INFO ("[linemod2D_CriticalDirectionBasedClustering]: template %d, critical_distance_int %d, translation_clustering_threshold %d\n", d.template_id, critical_distance_int, translation_clustering_threshold);
-    }
-    else{
-      critical_distance_int = 0;  //not using critical-direction
-    }
+    // use distance-in-narrow-Direction based Clustering for super long and narrow templates
+    int narrow_direction_distance_int;
+    float narrowDirection[2] = {0.0, 0.0};
+    narrowDirection[0] = templates_[d.template_id].narrowDirectionOfLongAndNarrowTemplate[0];
+    narrowDirection[1] = templates_[d.template_id].narrowDirectionOfLongAndNarrowTemplate[1];
+    float narrowDirectionDistance = static_cast< float >( d.x * narrowDirection[0] + d.y * narrowDirection[1] ); //std::sqrt(static_cast< float >( d.x * d.x + d.y * d.y ));
+    narrow_direction_distance_int = static_cast< int >(narrowDirectionDistance / translation_clustering_threshold_2D_in_narrow_direction_of_long_and_narrow_template);
+    // PCL_INFO ("[linemod2D_NarrowDirectionBasedClustering]: template %d, narrow_direction_distance_int %d, d.x / translation_clustering_threshold %d, d.y / translation_clustering_threshold %d\n", d.template_id, narrow_direction_distance_int, d.x / translation_clustering_threshold, d.y / translation_clustering_threshold);
     
     const ClusteringKey key = {
       d.x / translation_clustering_threshold,
       d.y / translation_clustering_threshold,
       d.template_id,
-      critical_distance_int,
+      narrow_direction_distance_int,
     };
 
     clusters[key].push_back(detection_id);

--- a/recognition/src/linemod.cpp
+++ b/recognition/src/linemod.cpp
@@ -316,11 +316,14 @@ pcl::LINEMOD::removeOverlappingDetections (
     }
 
     LINEMODDetection detection;
-    detection.template_id = best_template_id;
-    detection.score = average_score * inv_weight_sum * std::exp(-0.5f / elements_in_cluster);
-    detection.scale = average_scale * inv_weight_sum;
-    detection.x = int (average_region_x * inv_weight_sum);
-    detection.y = int (average_region_y * inv_weight_sum);
+    detection = detections[cluster[itIndexToBestScoreInCluster->second]];
+    // TODO:add also distant one in shortest extents' direction (assume always the same template in one cluster) 
+
+    // detection.template_id = best_template_id;
+    // detection.score = average_score * inv_weight_sum * std::exp(-0.5f / elements_in_cluster);
+    // detection.scale = average_scale * inv_weight_sum;
+    // detection.x = int (average_region_x * inv_weight_sum);
+    // detection.y = int (average_region_y * inv_weight_sum);
 
     clustered_detections.push_back (detection);
   }


### PR DESCRIPTION
In linemod2D,
1. use _highest-score candidate first_ in linemod2D clustering, instead of merging everything inside cluster.
2. add critical direction in linemod2D clustering.