### PR TITLE
Suppress cmake warnings for pcl modules

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -637,7 +637,8 @@ foreach(component ${PCL_TO_FIND_COMPONENTS})
   else(PCL_${COMPONENT}_INCLUDE_DIR)
     #pcl_message("No include directory found for pcl_${component}.")
   endif(PCL_${COMPONENT}_INCLUDE_DIR)
-  
+
+  set(FPHSA_NAME_MISMATCHED 1) # Suppress warnings, see https://cmake.org/cmake/help/v3.17/module/FindPackageHandleStandardArgs.html
   # Skip find_library for header only modules
   list(FIND pcl_header_only_components ${component} _is_header_only)
   if(_is_header_only EQUAL -1)
@@ -671,7 +672,8 @@ foreach(component ${PCL_TO_FIND_COMPONENTS})
     find_package_handle_standard_args(PCL_${COMPONENT} DEFAULT_MSG
       PCL_${COMPONENT}_INCLUDE_DIR)  
   endif(_is_header_only EQUAL -1)
-  
+  unset(FPHSA_NAME_MISMATCHED)
+
   if(PCL_${COMPONENT}_FOUND)
     if(NOT "${PCL_${COMPONENT}_INCLUDE_DIRS}" STREQUAL "")
       list(REMOVE_DUPLICATES PCL_${COMPONENT}_INCLUDE_DIRS)


### PR DESCRIPTION
cmake output got noisy after we updated cmake to 3.20 (which is 3.17 or later)